### PR TITLE
Callouts Title

### DIFF
--- a/plugin/custom/plugins/callouts.js
+++ b/plugin/custom/plugins/callouts.js
@@ -32,6 +32,12 @@ class calloutsPlugin extends BaseCustomPlugin {
             blockquote.classList.toggle("plugin-callout", ok);
             if (ok) {
                 const { type, fold } = result.groups;
+                // 为包含 [!type] 的 span 添加 data-type 属性
+                const firstSpan = p.querySelector('span:first-child');
+                // 设置为 type 标题
+                if (firstSpan) {
+                    firstSpan.setAttribute('data-type', type);
+                }
                 blockquote.setAttribute("callout-type", type.toLowerCase());
                 blockquote.classList.toggle("callout-folded", fold === "-");
             }

--- a/plugin/global/styles/callouts.css
+++ b/plugin/global/styles/callouts.css
@@ -24,6 +24,30 @@
     margin-right: 0.5em;
 }
 
+/* 默认显示 type */
+.plugin-callout > p:first-child > span:first-child {
+    font-weight: bold;
+    font-size: 0;
+}
+
+.plugin-callout > p:first-child > span:first-child::after {
+    content: attr(data-type);
+    font-size: initial;
+}
+
+/* 光标移动到标题行，即获得焦点时，显示原始的 [!type] */
+.plugin-callout > p:first-child > span:first-child:focus,
+.plugin-callout > p:first-child > span:first-child:focus-within,
+.plugin-callout > p:first-child.md-focus > span:first-child {
+    font-size: initial;
+}
+
+.plugin-callout > p:first-child > span:first-child:focus::after,
+.plugin-callout > p:first-child > span:first-child:focus-within::after,
+.plugin-callout > p:first-child.md-focus > span:first-child::after {
+    content: none;
+}
+
 .callout-folded > p:first-child :not(:first-child) { display: none; }
 .callout-folded > p:not(:first-child) { display: none; }
 


### PR DESCRIPTION
## 相关 Issue
Relate to #843

## 具体修改
1. 将原本显示为 `[!type]` 的标题改为直接显示 `type`
2. 在标题处悬停时显示 `[!type]` 提示，方便修改
3. 修改了相关的 CSS 和 JS 文件以实现此功能


## 前后对比
原先标题并没有渲染，显示为：

![image](https://github.com/user-attachments/assets/ac8b4ef6-8b06-479b-b6c9-a03299090728)


修改后：

![image](https://github.com/user-attachments/assets/386f4bde-375f-459e-a6e4-8cd4874bdb6b)

编辑时：

![image](https://github.com/user-attachments/assets/5d62c9a3-bc1c-418a-95d5-9f9d2fcd8346)


## 实际效果

![image](https://github.com/user-attachments/assets/8760c4f8-4092-4a33-b429-f48b7379f375)
