### PR TITLE
fix: the bug of missing Callout Icons when exporting

### DIFF
--- a/plugin/custom/plugins/callouts.js
+++ b/plugin/custom/plugins/callouts.js
@@ -51,11 +51,9 @@ class calloutsPlugin extends BaseCustomPlugin {
         return !isIgnoreType && hasCallout
     }
 
-    // The icon needs font, but there is no font when exporting, so it can only be removed.
     beforeExport = (...args) => {
         if (this.check(args)) {
-            const css = this.utils.styleTemplater.getStyleContent(this.fixedName)
-            return css.replace(/--callout-icon: ".*?";/g, "")
+            return this.utils.styleTemplater.getStyleContent(this.fixedName);
         }
     }
 

--- a/plugin/global/styles/callouts.css
+++ b/plugin/global/styles/callouts.css
@@ -1,3 +1,10 @@
+@font-face {
+    font-family: 'FontAwesome';
+    src: url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/fonts/fontawesome-webfont.woff) format('woff');
+    font-weight: normal;
+    font-style: normal;
+}
+
 .plugin-callout {
     background-color: var(--callout-bg-color);
     border-left: 4px solid var(--callout-left-line-color);


### PR DESCRIPTION
### 问题描述
在使用Typora的Callouts功能时，导出为PDF后图标不显示

主要因为导出过程中缺少必要的FontAwesome字体资源

### 解决方案
在 `callouts.css` 中添加 `FontAwesome` 字体的 `@font-face` 声明

### 具体改动
1. 在CSS中添加 `FontAwesome` 字体的 `@font-face` 声明，指向 CDN 资源
2. 移除了原先在 `beforeExport` 中删除图标CSS的逻辑

>[!warning]
依赖于外部 CDN