### PR TITLE
Refactor code title to CSS pseudo-element & add customizable CODE_TITLE_FORMAT

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -224,6 +224,23 @@ yay -S typora-plugin
 
 ### fence_enhance
 
+增强代码块：复制、折叠、格式化、代码块标题。
+
+**代码块标题（Code Title）：** 在 fence info 中添加 `title="xxx"`，代码块顶部会显示对应的标题栏。
+
+````markdown
+```js title="hello.js"
+const hello = 'world'
+```
+````
+
+支持通过 `{title}` 和 `{lang}` 占位符自定义标题栏格式：
+- `"{title}"`（默认）：显示 `hello.js`
+- `"{title} ({lang})"`：显示 `hello.js (js)`
+- `"{lang}"`：显示 `js`
+
+可在偏好设置 → fence_enhance → CODE_TITLE_FORMAT 中配置。
+
 ![fence_enhance](assets/fence_enhance.png)
 
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,23 @@ Resource management, cleanup of unused images
 
 ### fence_enhance
 
+Enhanced code block features: copy, fold, format, code title.
+
+**Code Title:** Add `title="xxx"` to fence info to display a title bar above the code block.
+
+````markdown
+```js title="hello.js"
+const hello = 'world'
+```
+````
+
+Customize the title format using `{title}` and `{lang}` placeholders:
+- `"{title}"` (default): renders `hello.js`
+- `"{title} ({lang})"`: renders `hello.js (js)`
+- `"{lang}"`: renders `js`
+
+Configure via Preferences → fence_enhance → CODE_TITLE_FORMAT.
+
 ![fence_enhance](assets/fence_enhance.png)
 
 

--- a/plugin/fence_enhance/index.js
+++ b/plugin/fence_enhance/index.js
@@ -16,7 +16,6 @@ class FenceEnhancePlugin extends BasePlugin {
 
   process = async () => {
     this.utils.settings.autoSave(this)
-
     if (this.config.ENABLE_BUTTON) this.buttonHelper.process()
     if (this.config.ENABLE_HOTKEY) new HotkeyHelper(this).process()
     if (this.config.HIGHLIGHT_BY_LANGUAGE) new HighlightHelper(this).process()
@@ -714,12 +713,12 @@ const codeTitle = ({ utils, config }) => {
     }`)
 
   utils.eventHub.addEventListener(utils.eventHub.eventType.afterAddCodeBlock, (cid, cm) => {
-    const fence = cm?.display.wrapper.parentElement
+    const fence = cm?.display.wrapper.parentElement ?? document.querySelector(`.md-fences[cid="${cid}"]`)
     if (fence) rerender(fence)
   })
   utils.eventHub.addEventListener(utils.eventHub.eventType.afterUpdateCodeBlockLang, ([node] = []) => {
     const cm = node?.cid && File.editor.fences.queue[node.cid]
-    const fence = cm?.display.wrapper.parentElement
+    const fence = cm?.display.wrapper.parentElement ?? document.querySelector(`.md-fences[cid="${node?.cid}"]`)
     if (fence) rerender(fence)
   })
 }

--- a/plugin/fence_enhance/index.js
+++ b/plugin/fence_enhance/index.js
@@ -682,40 +682,46 @@ const foldLanguage = async ({ utils }) => {
 }
 
 // See: https://vuepress.vuejs.org/guide/markdown.html#code-title
-const codeTitle = ({ utils }) => {
-  const className = "plugin-code-title"
+const codeTitle = ({ utils, config }) => {
+  const CLASS = "code-title-bar"
   const REGEX = /.+?\s+title="([^"]+)"/
+  const LANG_REGEX = /\s+title="[^"]+"/
 
-  const rerender = (cid) => {
-    if (!cid) return
-    const fence = document.querySelector(`.md-fences[cid="${cid}"]`)
-    if (!fence) return
-
-    let barEl = fence.querySelector(`.${className}`)
-    const title = fence.getAttribute("lang")?.match(REGEX)?.[1]
+  const rerender = (fence) => {
+    const lang = fence.getAttribute("lang")
+    const title = lang?.match(REGEX)?.[1]
     if (!title) {
-      barEl?.remove()
-    } else {
-      if (!barEl) {
-        barEl = document.createElement("div")
-        barEl.className = className
-        fence.prepend(barEl)
-      }
-      barEl.textContent = title
+      fence.classList.remove(CLASS)
+      return
     }
+    fence.classList.add(CLASS)
+    const langOnly = lang.replace(LANG_REGEX, "").trim()
+    const formatted = config.CODE_TITLE_FORMAT
+      .replace("{title}", title)
+      .replace("{lang}", langOnly)
+    fence.style.setProperty("--code-title", `"${formatted.replace(/"/g, '\\"')}"`)
   }
 
   utils.insertStyle("plugin-fence-enhance-code-title",
-    `.md-fences .${className} {
+    `.md-fences.${CLASS}::before {
+      content: var(--code-title);
+      display: block;
       padding: 6px 14px;
       border-bottom: 1px solid var(--code-title-border, #d0d0d0);
       margin-bottom: 6px;
       color: var(--code-title-text, currentColor);
       user-select: none;
-  }`)
+    }`)
 
-  utils.eventHub.addEventListener(utils.eventHub.eventType.afterAddCodeBlock, cid => rerender(cid))
-  utils.eventHub.addEventListener(utils.eventHub.eventType.afterUpdateCodeBlockLang, ([node] = []) => rerender(node?.cid))
+  utils.eventHub.addEventListener(utils.eventHub.eventType.afterAddCodeBlock, (cid, cm) => {
+    const fence = cm?.display.wrapper.parentElement
+    if (fence) rerender(fence)
+  })
+  utils.eventHub.addEventListener(utils.eventHub.eventType.afterUpdateCodeBlockLang, ([node] = []) => {
+    const cm = node?.cid && File.editor.fences.queue[node.cid]
+    const fence = cm?.display.wrapper.parentElement
+    if (fence) rerender(fence)
+  })
 }
 
 module.exports = {

--- a/plugin/global/locales/en.json
+++ b/plugin/global/locales/en.json
@@ -717,6 +717,7 @@
     "$label.HIGHLIGHT_ON_FOCUS": "Highlight on Focus",
     "$label.HIGHLIGHT_LINE_COLOR_ON_FOCUS": "Focus Background Color",
     "$label.ENABLE_CODE_TITLE": "Code Title",
+    "$label.CODE_TITLE_FORMAT": "Title Format",
     "$title.buttonGeneral": "Button",
     "$title.functionButtons": "Function Buttons",
     "$title.buttonHotkeys": "Code Block Hotkeys",

--- a/plugin/global/locales/zh-CN.json
+++ b/plugin/global/locales/zh-CN.json
@@ -717,6 +717,7 @@
     "$label.HIGHLIGHT_ON_FOCUS": "光标聚焦高亮",
     "$label.HIGHLIGHT_LINE_COLOR_ON_FOCUS": "高亮背景色",
     "$label.ENABLE_CODE_TITLE": "代码标题",
+    "$label.CODE_TITLE_FORMAT": "标题格式",
     "$title.buttonGeneral": "按钮",
     "$title.functionButtons": "功能按钮",
     "$title.buttonHotkeys": "代码块快捷键",

--- a/plugin/global/locales/zh-TW.json
+++ b/plugin/global/locales/zh-TW.json
@@ -717,6 +717,7 @@
     "$label.HIGHLIGHT_ON_FOCUS": "游標聚焦高亮",
     "$label.HIGHLIGHT_LINE_COLOR_ON_FOCUS": "高亮背景色",
     "$label.ENABLE_CODE_TITLE": "程式碼區塊標題",
+    "$label.CODE_TITLE_FORMAT": "標題格式",
     "$title.buttonGeneral": "按鈕",
     "$title.functionButtons": "功能按鈕",
     "$title.buttonHotkeys": "程式碼區塊快捷鍵",

--- a/plugin/global/settings/settings.default.toml
+++ b/plugin/global/settings/settings.default.toml
@@ -1235,9 +1235,16 @@ HIGHLIGHT_LINE_COLOR_ON_FOCUS = "rgba(142, 150, 170, 0.14)"
 
 # =========== [ Code Title ] ===========
 # Enable code title
+# Add title="xxx" to fence info to show a title bar:
+#   ```js title="hello.js"
+#   const hello = 'world'
+#   ```
 # See: https://vuepress.vuejs.org/guide/markdown.html#code-blocks
 ENABLE_CODE_TITLE = false
-# Title text format. Supports {title} and {lang} placeholders. Example: "{title} ({lang})"
+# Title text format. Supports {title} and {lang} placeholders.
+#   "{title}"           → "hello.js"
+#   "{title} ({lang})"  → "hello.js (js)"
+#   "{lang}"            → "js"
 CODE_TITLE_FORMAT = "{title}"
 
 # =========== [ Advanced ] ===========

--- a/plugin/global/settings/settings.default.toml
+++ b/plugin/global/settings/settings.default.toml
@@ -1237,6 +1237,8 @@ HIGHLIGHT_LINE_COLOR_ON_FOCUS = "rgba(142, 150, 170, 0.14)"
 # Enable code title
 # See: https://vuepress.vuejs.org/guide/markdown.html#code-blocks
 ENABLE_CODE_TITLE = false
+# Title text format. Supports {title} and {lang} placeholders. Example: "{title} ({lang})"
+CODE_TITLE_FORMAT = "{title}"
 
 # =========== [ Advanced ] ===========
 # Auto-align wrapped lines: Maintain proper indentation for long, wrapped text lines. Note: High rendering performance cost

--- a/plugin/preferences/schemas.js
+++ b/plugin/preferences/schemas.js
@@ -592,6 +592,7 @@ const schema_fence_enhance = () => [
     Text("HIGHLIGHT_LINE_COLOR_ON_HOVER").ShowIf(When.true("HIGHLIGHT_ON_HOVER")),
   ),
   Switch("ENABLE_CODE_TITLE").ActionTooltip("viewVuePressCodeTitle"),
+  Text("CODE_TITLE_FORMAT").ShowIf(When.true("ENABLE_CODE_TITLE")),
   Group("advanced",
     Switch("SIDE_BY_SIDE_VIEW").ActionTooltip("viewSideBySideEffect").Tooltip("stylisticConfusion"),
     Switch("VISIBLE_TABS").ActionTooltip("viewVisibleTabsEffect"),


### PR DESCRIPTION
⚙️ 代码标题从真实 DOM <div> 改为 ::before 伪元素方案，更轻量简洁
⚙️ 新增 CODE_TITLE_FORMAT 配置项，支持 {title} / {lang} 占位符自定义格式
⚙️ 更新 中/英/繁三语 i18n、默认配置、偏好设置 schema 和 README 文档