### PR TITLE
feat(file_rules): Add file paste/drop rules plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# AGENTS.md
+
+This file provides guidance to Qoder (lingma.aliyun.com) when working with code in this repository.
+
+## Project Overview
+
+Typora Plugin is an extensible plugin system for the Typora Markdown editor. It injects into Typora's Electron-based runtime (via `window.html`) and provides 50+ plugins. The project is pure JavaScript (no TypeScript), requires Typora >= 0.9.98, and supports Windows and Linux.
+
+## Commands
+
+All commands run from the `develop/` directory. Requires Node.js >= 22.
+
+```bash
+cd develop
+npm install          # Install dev dependencies
+
+# Testing (uses Node.js built-in test runner: node:test + node:assert)
+npm test                                    # Run all tests
+node --require ../plugin/global/core/polyfill.js --test test/utils.test.js   # Run single test file
+
+# Building vendored dependencies (esbuild bundles NPM packages into plugin/global/core/lib/)
+npm run build:all                           # Build all vendors
+npm run build:single                        # Build a single vendor (edit arg in package.json, e.g. "katex")
+npm run build:download                      # Build download-type vendors (js-yaml, markdown-it, etc.)
+
+# Development (requires TYPORA_PATH set in develop/.env)
+npm run dev                                 # Development mode
+npm run sync                                # Watch plugin/ for changes, sync to Typora install dir
+npm run serve                               # Sync + auto-restart Typora via JSON-RPC
+npm run rpc                                 # JSON-RPC connection to running Typora
+```
+
+## Architecture
+
+### Entry Point Flow
+
+1. `plugin/index.js` -- loaded by modified `window.html`, requires `plugin/global/core/index.js`
+2. `plugin/global/core/index.js` -- `entry()` function: checks Typora version, reads TOML settings, sets up globals (`BasePlugin`, `BaseCustomPlugin`), initializes i18n, loads all plugins via mixin chain, publishes `allPluginsHadInjected` event
+
+### Core Framework (`plugin/global/core/`)
+
+- **`plugin.js`** -- Defines `IPlugin` (base interface), `BasePlugin`, `BaseCustomPlugin` classes, and `LoadPlugins()` which drives the plugin lifecycle
+- **`serviceContainer.js`** -- Singleton storing all plugin instances and settings; provides lookup APIs (`getBasePlugin()`, `tryGetPlugin()`)
+- **`i18n.js`** -- i18n system supporting `en`, `zh-CN`, `zh-TW`; loads JSON locale files from `plugin/global/locales/`
+- **`polyfill.js`** -- Polyfills for older Electron/Node (`Object.hasOwn`, `Promise.withResolvers`, etc.)
+
+### Core Utilities (`plugin/global/core/utils/`)
+
+- **`index.js`** -- Large utility class (~200+ static methods): DOM manipulation, file ops, path handling, HTML/CSS injection. Instantiates all mixins.
+- **`eventHub.js`** -- Event bus with typed events (`fileOpened`, `fileEdited`, `outlineUpdated`, etc.). Uses MutationObserver and decorator hooks.
+- **`hotkeyHub.js`** -- Global hotkey registration/dispatch. Normalizes key combos (Ctrl+Shift+Alt+Key).
+- **`decorator.js`** -- AOP system. Wraps Typora's internal functions with before/after hooks, argument/result modification, call prevention. Supports decorator chaining with priorities.
+- **`settings.js`** -- TOML settings reader (default + user), supports save/import/export, auto-save via Proxy.
+- **`styleManager.js`** -- CSS loading with template variable substitution (`${config.value}`).
+- **`thirdPartyDiagramParser.js`** -- Extended diagram framework with lazy-loading and export support.
+
+### Plugin System
+
+**Plugin Lifecycle** (in order): `prepare()` -> `style()` -> `html()` -> `hotkey()` -> `init()` -> `process()` -> `finalize()`
+
+**Two plugin types:**
+
+1. **Base Plugins** (in `plugin/`) -- Extend `BasePlugin`, implement `call(action, meta)`. Can be single-file (`plugin/{name}.js`) or directory-based (`plugin/{name}/index.js` with resources).
+2. **Custom Plugins** (in `plugin/custom/plugins/`) -- Extend `BaseCustomPlugin`, implement `selector()`, `hint()`, `callback()`. Managed by the `custom` base plugin (`plugin/custom/index.js`). User-populated, empty by default.
+
+### Settings System (`plugin/global/settings/`)
+
+- `settings.default.toml` (~120KB) -- Default config for all base plugins. Each plugin has `[plugin_name]` section with `ENABLE`, `NAME`, and plugin-specific options.
+- `settings.user.toml` -- User overrides
+- `custom_plugin.default.toml` / `custom_plugin.user.toml` -- Same pattern for custom plugins
+- Supports home directory override (`~/.config/typora_plugin/`) for persistence across updates
+
+### Key Patterns
+
+- **Service Container / DI**: `ServiceContainer` singleton holds all plugin instances, accessible via `utils.container`
+- **AOP (Aspect-Oriented Programming)**: `decorator.js` wraps Typora internals without modifying source. Used by `eventHub`, `exportHelper`, and many plugins.
+- **Mixin Architecture**: Core features (eventHub, hotkeyHub, styleManager, etc.) are mixins on the `utils` class, each with `process()` and optional `postprocess()` lifecycle methods
+- **Vendored Dependencies**: All NPM dependencies are pre-bundled via esbuild into `plugin/global/core/lib/` -- no runtime `npm install` needed in `plugin/`
+- **Event-Driven**: Rich event system for file operations, code block changes, sidebar toggling, etc.
+
+## Code Style
+
+- Pure JavaScript, no TypeScript
+- UTF-8, 2-space indent, LF line endings (see `.editorconfig`)
+- All UI strings go through the i18n system (locale files in `plugin/global/locales/`)
+- When adding a new plugin: add a `[plugin_name]` section to `settings.default.toml` with at least `ENABLE` and `NAME` keys, add translations to all three locale JSON files, and optionally add a CSS file to `plugin/global/styles/`
+
+## Testing
+
+- Framework: Node.js built-in `node:test` + `node:assert`
+- Test files are in `develop/test/`
+- Tests use JSDOM for DOM mocking (`develop/test/mocks/dom.mock.js`), proxyquire for module mocking (`utils.mock.js`), and fixture files for integration-style tests
+- The polyfill (`plugin/global/core/polyfill.js`) must be loaded via `--require` before tests
+
+## Build System
+
+The build (`develop/build/index.cjs`) uses esbuild to bundle NPM dependencies into standalone files under `plugin/global/core/lib/` and individual plugin directories. Three vendor types:
+- **download**: Fetch minified files from CDN/GitHub
+- **bundle**: esbuild bundles NPM packages (options: `{ bundle: true, minify: true, platform: "node", target: "node12.14" }`)
+- **dist**: Copy NPM package assets directly (e.g., katex fonts + CSS)
+
+## CI/CD
+
+- `TestOnCommit.yaml` -- Runs `npm ci && npm test` on push to `develop/**`, `plugin/**`, `.github/**` (Node 20.x and 24.x matrix)
+- `PublishOnTag.yaml` -- On tag `X.Y.Z`, creates version.json, zips `plugin/`, publishes GitHub Release

--- a/develop/package-lock.json
+++ b/develop/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "develop",
       "dependencies": {
         "@marp-team/marp-core": "^4.3.0",
         "@moritzrs/mdast-util-ofm": "^0.0.1",

--- a/plugin/assets_storage.js
+++ b/plugin/assets_storage.js
@@ -1,27 +1,9 @@
-class FileRulesPlugin extends BasePlugin {
+class AssetsStoragePlugin extends BasePlugin {
   imageExtensions = new Set([
     "jpg", "jpeg", "png", "gif", "svg", "webp", "bmp", "tiff", "ico", "jfif",
   ])
 
-  prepare = () => {
-    if (!this.config.COPY_TO_ASSETS) {
-      return this.utils.PLUGIN_LOAD_ABORT
-    }
-  }
-
   process = () => {
-    // Images: leverage Typora's native defaultImageStorage mechanism.
-    // Override the target folder so Typora handles copying & markdown insertion.
-    const getImgEdit = () => File?.editor?.imgEdit
-    this.utils.decorator.modifyReturn(getImgEdit, "getTargetImageStorageFolderFromSetting", (original) => {
-      return this._getTargetFolder() || original
-    })
-    this.utils.decorator.modifyReturn(getImgEdit, "getTargetImageStorageFolder", (original) => {
-      return this._getTargetFolder() || original
-    })
-
-    // Non-image files (pdf, exe, msi, etc.): Typora has no native storage
-    // for these, so we handle paste/drop ourselves with the same folder rules.
     this.utils.entities.eWrite.addEventListener("paste", this._handlePaste, { capture: true })
     this.utils.entities.eWrite.addEventListener("drop", this._handleDrop, { capture: true })
   }
@@ -29,37 +11,25 @@ class FileRulesPlugin extends BasePlugin {
   _handlePaste = (ev) => {
     const files = ev.clipboardData?.files
     if (!files || files.length === 0) return
-    this._processFiles(files, ev).catch(e => console.error("[file_rules] paste error:", e))
+    this._processFiles(files, ev).catch(e => console.error("[assets_storage] paste error:", e))
   }
 
   _handleDrop = (ev) => {
     const files = ev.dataTransfer?.files
     if (!files || files.length === 0) return
-    this._processFiles(files, ev).catch(e => console.error("[file_rules] drop error:", e))
+    this._processFiles(files, ev).catch(e => console.error("[assets_storage] drop error:", e))
   }
 
   _processFiles = async (fileList, ev) => {
     const files = Array.from(fileList)
-    // If event contains ONLY images, let Typora handle them natively (decorator applies)
-    const hasNonImage = files.some(f => !this._isImage(f))
-    if (!hasNonImage) return
 
     // Resolve targetFolder BEFORE preventDefault — if we can't determine a
     // folder (e.g. upload/ipic mode), bail out and let Typora handle the event.
     const targetFolder = this._getTargetFolder()
     if (!targetFolder) return
 
-    // When non-image files are present, we handle ALL files in the event.
-    // preventDefault is necessary for non-images, but it also blocks Typora's
-    // image handler — so we process images here too to avoid silent data loss.
     ev.preventDefault()
     ev.stopPropagation()
-
-    const filePath = this.utils.getFilePath()
-    if (!filePath) {
-      this.utils.notification.show(this.i18n.t("notify.noFile"), "warning")
-      return
-    }
 
     const markdownParts = []
     let successCount = 0
@@ -85,7 +55,7 @@ class FileRulesPlugin extends BasePlugin {
         markdownParts.push(this._generateMarkdown(finalPath, displayName, isImage))
         successCount++
       } catch (e) {
-        console.error("[file_rules]", e)
+        console.error("[assets_storage]", e)
         this.utils.notification.show(
           this.i18n.t("notify.copyFailed", { error: e.message }),
           "error",
@@ -108,8 +78,17 @@ class FileRulesPlugin extends BasePlugin {
 
   _isImage = (file) => {
     if (file.type && file.type.startsWith("image/")) return true
-    const ext = this._getExtension(file).toLowerCase()
-    return this.imageExtensions.has(ext)
+    if (file.name) {
+      const idx = file.name.lastIndexOf(".")
+      if (idx !== -1) {
+        return this.imageExtensions.has(file.name.substring(idx + 1).toLowerCase())
+      }
+    }
+    if (file.type) {
+      const subtype = file.type.split("/")[1]
+      if (subtype) return this.imageExtensions.has(subtype.toLowerCase())
+    }
+    return false
   }
 
   _getFilePath = (file) => {
@@ -167,11 +146,9 @@ class FileRulesPlugin extends BasePlugin {
     const fileName = this.utils.getFileName(filePath, true)
 
     // Read Typora's native defaultImageStorage setting directly.
-    // We CANNOT call getTargetImageStorageFolder() here — it's been decorated
-    // by this plugin and would cause infinite recursion.
     const storage = File?.option?.defaultImageStorage
     if (!storage || storage === "upload" || storage === "ipic") {
-      return null  // Let decorator fall through to original Typora behavior
+      return null
     }
 
     if (storage === "folder") {
@@ -185,18 +162,6 @@ class FileRulesPlugin extends BasePlugin {
     }
     // Custom path (may contain ${filename} placeholder)
     return Path.resolve(currentDir, storage.replace(/\${filename}/g, fileName))
-  }
-
-  _getExtension = (file) => {
-    if (file.name) {
-      const idx = file.name.lastIndexOf(".")
-      if (idx !== -1) return file.name.substring(idx + 1)
-    }
-    if (file.type) {
-      const subtype = file.type.split("/")[1]
-      if (subtype) return subtype
-    }
-    return ""
   }
 
   _escapeUrl = (path) => {
@@ -214,5 +179,5 @@ class FileRulesPlugin extends BasePlugin {
 }
 
 module.exports = {
-  plugin: FileRulesPlugin,
+  plugin: AssetsStoragePlugin,
 }

--- a/plugin/file_rules.js
+++ b/plugin/file_rules.js
@@ -1,0 +1,224 @@
+class FileRulesPlugin extends BasePlugin {
+  rule = null
+  imageExtensions = new Set([
+    "jpg", "jpeg", "png", "gif", "svg", "webp", "bmp", "tiff", "ico", "jfif",
+  ])
+
+  prepare = () => {
+    const { COPY_TO_ASSETS, USE_RELATIVE_PATH, ESCAPE_URL, TARGET_FOLDER } = this.config
+
+    const hasRule = COPY_TO_ASSETS || USE_RELATIVE_PATH || ESCAPE_URL
+    if (hasRule) {
+      this.rule = {
+        copy_to_assets: COPY_TO_ASSETS,
+        use_relative_path: USE_RELATIVE_PATH,
+        escape_url: ESCAPE_URL,
+        target_folder: TARGET_FOLDER,
+      }
+    }
+
+    if (!this.rule) {
+      return this.utils.PLUGIN_LOAD_ABORT
+    }
+  }
+
+  process = () => {
+    this.utils.entities.eWrite.addEventListener("paste", this._handlePaste, { capture: true })
+    this.utils.entities.eWrite.addEventListener("drop", this._handleDrop, { capture: true })
+  }
+
+  _handlePaste = (ev) => {
+    const files = ev.clipboardData?.files
+    if (!files || files.length === 0) return
+    this._processFiles(files, ev).catch(e => console.error("[file_rules] paste error:", e))
+  }
+
+  _handleDrop = (ev) => {
+    const files = ev.dataTransfer?.files
+    if (!files || files.length === 0) return
+    this._processFiles(files, ev).catch(e => console.error("[file_rules] drop error:", e))
+  }
+
+  _processFiles = async (fileList, ev) => {
+    if (!this.rule || fileList.length === 0) return
+
+    // Immediately prevent default to stop Typora's built-in handler
+    ev.preventDefault()
+    ev.stopPropagation()
+
+    const markdownParts = []
+    let successCount = 0
+    let targetFolder = ""
+    for (const file of fileList) {
+      try {
+        const result = await this._processFile(file)
+        if (result) {
+          markdownParts.push(result.markdown)
+          successCount++
+          if (!targetFolder && result.targetFolder) {
+            targetFolder = result.targetFolder
+          }
+        }
+      } catch (e) {
+        console.error("[file_rules]", e)
+        this.utils.notification.show(
+          this.i18n.t("notify.copyFailed", { error: e.message }),
+          "error",
+        )
+      }
+    }
+
+    if (successCount > 0 && targetFolder) {
+      const { Path } = this.utils.Package
+      const folderName = Path.basename(targetFolder)
+      this.utils.notification.show(
+        this.i18n.t("notify.copySuccessBatch", { count: successCount, folder: folderName }),
+        "success",
+      )
+    }
+
+    if (markdownParts.length > 0) {
+      this.utils.insertText(null, markdownParts.join("\n\n"))
+    }
+  }
+
+  _processFile = async (file) => {
+    const filePath = this.utils.getFilePath()
+    if (!filePath) {
+      this.utils.notification.show(this.i18n.t("notify.noFile"), "warning")
+      return null
+    }
+
+    const currentDir = this.utils.getCurrentDirPath()
+    const fileName = this.utils.getFileName(filePath, true)
+    const rule = this.rule
+    const targetDir = this._resolveTargetFolder(rule, currentDir, fileName)
+
+    const { FsExtra, Path } = this.utils.Package
+
+    let destPath
+    if (rule.copy_to_assets) {
+      await FsExtra.ensureDir(targetDir)
+      const ext = this._getExtension(file)
+      const originalName = file.name || `file-${this._timestamp()}.${ext}`
+      destPath = await this._copyFile(file, targetDir, originalName, FsExtra, Path)
+      if (!destPath) return null
+    } else {
+      destPath = file.path
+      if (!destPath) {
+        console.error("[file_rules] Cannot use original file: file.path is not available")
+        throw new Error(this.i18n.t("notify.noOriginalPath"))
+      }
+    }
+
+    let finalPath
+    if (rule.use_relative_path) {
+      finalPath = Path.relative(currentDir, destPath)
+      finalPath = finalPath.replace(/\\/g, "/")
+    } else {
+      finalPath = destPath
+    }
+
+    if (rule.escape_url) {
+      finalPath = this._escapeUrl(finalPath)
+    }
+
+    const ext = this._getExtension(file)
+    const isImage = this.imageExtensions.has(ext.toLowerCase())
+    const displayName = Path.basename(destPath, Path.extname(destPath))
+    const markdown = this._generateMarkdown(finalPath, displayName, isImage)
+
+    return {
+      markdown,
+      targetFolder: rule.copy_to_assets ? targetDir : null,
+    }
+  }
+
+  _resolveTargetFolder = (rule, currentDir, fileName) => {
+    const { Path } = this.utils.Package
+    if (rule.target_folder) {
+      return Path.resolve(currentDir, rule.target_folder)
+    }
+    return Path.resolve(currentDir, `${fileName}.assets`)
+  }
+
+  _copyFile = async (file, targetDir, originalName, FsExtra, Path) => {
+    let destName = Path.basename(originalName)
+    if (destName.includes("/") || destName.includes("\\") || destName === "..") {
+      console.error("[file_rules] Path traversal attempt blocked:", originalName)
+      throw new Error(this.i18n.t("notify.pathTraversal"))
+    }
+
+    let destPath = Path.join(targetDir, destName)
+
+    if (file.path && Path.resolve(file.path) === Path.resolve(destPath)) {
+      return destPath
+    }
+
+    let counter = 1
+    const maxAttempts = 100
+    while (await this.utils.existPath(destPath)) {
+      if (counter >= maxAttempts) {
+        throw new Error(
+          this.i18n.t("notify.fileNameCollision", { name: destName })
+        )
+      }
+      const ext = Path.extname(destName)
+      const base = Path.basename(destName, ext)
+      destName = `${base}-${counter}${ext}`
+      destPath = Path.join(targetDir, destName)
+      counter++
+    }
+
+    const resolvedPath = Path.resolve(targetDir, destName)
+    const resolvedTarget = Path.resolve(targetDir) + Path.sep
+    if (resolvedPath !== Path.resolve(targetDir) && !resolvedPath.startsWith(resolvedTarget)) {
+      console.error("[file_rules] Path traversal blocked after resolution:", resolvedPath)
+      throw new Error(this.i18n.t("notify.pathTraversal"))
+    }
+
+    if (file.path) {
+      await FsExtra.copy(file.path, destPath)
+    } else {
+      const buffer = Buffer.from(await file.arrayBuffer())
+      await FsExtra.writeFile(destPath, buffer)
+    }
+
+    return destPath
+  }
+
+  _getExtension = (file) => {
+    if (file.name) {
+      const idx = file.name.lastIndexOf(".")
+      if (idx !== -1) return file.name.substring(idx + 1)
+    }
+    if (file.type) {
+      const subtype = file.type.split("/")[1]
+      if (subtype) return subtype
+    }
+    return ""
+  }
+
+  _escapeUrl = (path) => {
+    return path
+      .split("/")
+      .map(segment => encodeURIComponent(segment))
+      .join("/")
+  }
+
+  _generateMarkdown = (relativePath, displayName, isImage) => {
+    const prefix = isImage ? "!" : ""
+    const safeName = displayName.replace(/[\[\]()]/g, "\\$&")
+    return `${prefix}[${safeName}](${relativePath})`
+  }
+
+  _timestamp = () => {
+    const now = new Date()
+    const pad = n => String(n).padStart(2, "0")
+    return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`
+  }
+}
+
+module.exports = {
+  plugin: FileRulesPlugin,
+}

--- a/plugin/file_rules.js
+++ b/plugin/file_rules.js
@@ -1,28 +1,27 @@
 class FileRulesPlugin extends BasePlugin {
-  rule = null
   imageExtensions = new Set([
     "jpg", "jpeg", "png", "gif", "svg", "webp", "bmp", "tiff", "ico", "jfif",
   ])
 
   prepare = () => {
-    const { COPY_TO_ASSETS, USE_RELATIVE_PATH, ESCAPE_URL, TARGET_FOLDER } = this.config
-
-    const hasRule = COPY_TO_ASSETS || USE_RELATIVE_PATH || ESCAPE_URL
-    if (hasRule) {
-      this.rule = {
-        copy_to_assets: COPY_TO_ASSETS,
-        use_relative_path: USE_RELATIVE_PATH,
-        escape_url: ESCAPE_URL,
-        target_folder: TARGET_FOLDER,
-      }
-    }
-
-    if (!this.rule) {
+    if (!this.config.COPY_TO_ASSETS) {
       return this.utils.PLUGIN_LOAD_ABORT
     }
   }
 
   process = () => {
+    // Images: leverage Typora's native defaultImageStorage mechanism.
+    // Override the target folder so Typora handles copying & markdown insertion.
+    const getImgEdit = () => File?.editor?.imgEdit
+    this.utils.decorator.modifyReturn(getImgEdit, "getTargetImageStorageFolderFromSetting", (original) => {
+      return this._getTargetFolder() || original
+    })
+    this.utils.decorator.modifyReturn(getImgEdit, "getTargetImageStorageFolder", (original) => {
+      return this._getTargetFolder() || original
+    })
+
+    // Non-image files (pdf, exe, msi, etc.): Typora has no native storage
+    // for these, so we handle paste/drop ourselves with the same folder rules.
     this.utils.entities.eWrite.addEventListener("paste", this._handlePaste, { capture: true })
     this.utils.entities.eWrite.addEventListener("drop", this._handleDrop, { capture: true })
   }
@@ -40,25 +39,51 @@ class FileRulesPlugin extends BasePlugin {
   }
 
   _processFiles = async (fileList, ev) => {
-    if (!this.rule || fileList.length === 0) return
+    const files = Array.from(fileList)
+    // If event contains ONLY images, let Typora handle them natively (decorator applies)
+    const hasNonImage = files.some(f => !this._isImage(f))
+    if (!hasNonImage) return
 
-    // Immediately prevent default to stop Typora's built-in handler
+    // Resolve targetFolder BEFORE preventDefault — if we can't determine a
+    // folder (e.g. upload/ipic mode), bail out and let Typora handle the event.
+    const targetFolder = this._getTargetFolder()
+    if (!targetFolder) return
+
+    // When non-image files are present, we handle ALL files in the event.
+    // preventDefault is necessary for non-images, but it also blocks Typora's
+    // image handler — so we process images here too to avoid silent data loss.
     ev.preventDefault()
     ev.stopPropagation()
 
+    const filePath = this.utils.getFilePath()
+    if (!filePath) {
+      this.utils.notification.show(this.i18n.t("notify.noFile"), "warning")
+      return
+    }
+
     const markdownParts = []
     let successCount = 0
-    let targetFolder = ""
-    for (const file of fileList) {
+
+    const { FsExtra, Path } = this.utils.Package
+    await FsExtra.ensureDir(targetFolder)
+    const currentDir = this.utils.getCurrentDirPath()
+
+    for (const file of files) {
       try {
-        const result = await this._processFile(file)
-        if (result) {
-          markdownParts.push(result.markdown)
-          successCount++
-          if (!targetFolder && result.targetFolder) {
-            targetFolder = result.targetFolder
-          }
+        const sourcePath = this._getFilePath(file)
+        const isImage = this._isImage(file)
+
+        const destPath = await this._copyFile(file, targetFolder, sourcePath, FsExtra, Path)
+        let finalPath = File.option.useRelativePathForImg
+          ? Path.relative(currentDir, destPath).replace(/\\/g, "/")
+          : destPath
+        if (File.option.autoEscapeImageURL) {
+          finalPath = this._escapeUrl(finalPath)
         }
+
+        const displayName = Path.basename(destPath, Path.extname(destPath))
+        markdownParts.push(this._generateMarkdown(finalPath, displayName, isImage))
+        successCount++
       } catch (e) {
         console.error("[file_rules]", e)
         this.utils.notification.show(
@@ -68,8 +93,7 @@ class FileRulesPlugin extends BasePlugin {
       }
     }
 
-    if (successCount > 0 && targetFolder) {
-      const { Path } = this.utils.Package
+    if (successCount > 0) {
       const folderName = Path.basename(targetFolder)
       this.utils.notification.show(
         this.i18n.t("notify.copySuccessBatch", { count: successCount, folder: folderName }),
@@ -82,86 +106,34 @@ class FileRulesPlugin extends BasePlugin {
     }
   }
 
-  _processFile = async (file) => {
-    const filePath = this.utils.getFilePath()
-    if (!filePath) {
-      this.utils.notification.show(this.i18n.t("notify.noFile"), "warning")
-      return null
-    }
-
-    const currentDir = this.utils.getCurrentDirPath()
-    const fileName = this.utils.getFileName(filePath, true)
-    const rule = this.rule
-    const targetDir = this._resolveTargetFolder(rule, currentDir, fileName)
-
-    const { FsExtra, Path } = this.utils.Package
-
-    let destPath
-    if (rule.copy_to_assets) {
-      await FsExtra.ensureDir(targetDir)
-      const ext = this._getExtension(file)
-      const originalName = file.name || `file-${this._timestamp()}.${ext}`
-      destPath = await this._copyFile(file, targetDir, originalName, FsExtra, Path)
-      if (!destPath) return null
-    } else {
-      destPath = file.path
-      if (!destPath) {
-        console.error("[file_rules] Cannot use original file: file.path is not available")
-        throw new Error(this.i18n.t("notify.noOriginalPath"))
-      }
-    }
-
-    let finalPath
-    if (rule.use_relative_path) {
-      finalPath = Path.relative(currentDir, destPath)
-      finalPath = finalPath.replace(/\\/g, "/")
-    } else {
-      finalPath = destPath
-    }
-
-    if (rule.escape_url) {
-      finalPath = this._escapeUrl(finalPath)
-    }
-
-    const ext = this._getExtension(file)
-    const isImage = this.imageExtensions.has(ext.toLowerCase())
-    const displayName = Path.basename(destPath, Path.extname(destPath))
-    const markdown = this._generateMarkdown(finalPath, displayName, isImage)
-
-    return {
-      markdown,
-      targetFolder: rule.copy_to_assets ? targetDir : null,
-    }
+  _isImage = (file) => {
+    if (file.type && file.type.startsWith("image/")) return true
+    const ext = this._getExtension(file).toLowerCase()
+    return this.imageExtensions.has(ext)
   }
 
-  _resolveTargetFolder = (rule, currentDir, fileName) => {
-    const { Path } = this.utils.Package
-    if (rule.target_folder) {
-      return Path.resolve(currentDir, rule.target_folder)
-    }
-    return Path.resolve(currentDir, `${fileName}.assets`)
+  _getFilePath = (file) => {
+    if (file.path) return file.path
+    try {
+      const { webUtils } = reqnode("electron")
+      const p = webUtils?.getPathForFile?.(file)
+      if (p) return p
+    } catch (_) {}
+    return null
   }
 
-  _copyFile = async (file, targetDir, originalName, FsExtra, Path) => {
-    let destName = Path.basename(originalName)
-    if (destName.includes("/") || destName.includes("\\") || destName === "..") {
-      console.error("[file_rules] Path traversal attempt blocked:", originalName)
-      throw new Error(this.i18n.t("notify.pathTraversal"))
-    }
+  _copyFile = async (file, targetDir, sourcePath, FsExtra, Path) => {
+    let destName = Path.basename(file.name || (sourcePath ? Path.basename(sourcePath) : `file-${Date.now()}`))
 
     let destPath = Path.join(targetDir, destName)
-
-    if (file.path && Path.resolve(file.path) === Path.resolve(destPath)) {
+    if (sourcePath && Path.resolve(sourcePath) === Path.resolve(destPath)) {
       return destPath
     }
 
     let counter = 1
-    const maxAttempts = 100
     while (await this.utils.existPath(destPath)) {
-      if (counter >= maxAttempts) {
-        throw new Error(
-          this.i18n.t("notify.fileNameCollision", { name: destName })
-        )
+      if (counter >= 100) {
+        throw new Error(this.i18n.t("notify.fileNameCollision", { name: destName }))
       }
       const ext = Path.extname(destName)
       const base = Path.basename(destName, ext)
@@ -170,21 +142,49 @@ class FileRulesPlugin extends BasePlugin {
       counter++
     }
 
-    const resolvedPath = Path.resolve(targetDir, destName)
+    // Path traversal guard
+    const resolved = Path.resolve(destPath)
     const resolvedTarget = Path.resolve(targetDir) + Path.sep
-    if (resolvedPath !== Path.resolve(targetDir) && !resolvedPath.startsWith(resolvedTarget)) {
-      console.error("[file_rules] Path traversal blocked after resolution:", resolvedPath)
+    if (resolved !== Path.resolve(targetDir) && !resolved.startsWith(resolvedTarget)) {
       throw new Error(this.i18n.t("notify.pathTraversal"))
     }
 
-    if (file.path) {
-      await FsExtra.copy(file.path, destPath)
+    if (sourcePath) {
+      await FsExtra.copy(sourcePath, destPath)
     } else {
       const buffer = Buffer.from(await file.arrayBuffer())
       await FsExtra.writeFile(destPath, buffer)
     }
-
     return destPath
+  }
+
+  _getTargetFolder = () => {
+    const filePath = this.utils.getFilePath()
+    if (!filePath) return null
+
+    const { Path } = this.utils.Package
+    const currentDir = this.utils.getCurrentDirPath()
+    const fileName = this.utils.getFileName(filePath, true)
+
+    // Read Typora's native defaultImageStorage setting directly.
+    // We CANNOT call getTargetImageStorageFolder() here — it's been decorated
+    // by this plugin and would cause infinite recursion.
+    const storage = File?.option?.defaultImageStorage
+    if (!storage || storage === "upload" || storage === "ipic") {
+      return null  // Let decorator fall through to original Typora behavior
+    }
+
+    if (storage === "folder") {
+      return Path.normalize(currentDir.replace(/[\\/]$/, ""))
+    }
+    if (storage === "assert") {
+      return Path.resolve(currentDir, "assets")
+    }
+    if (storage === "per-file-assert") {
+      return Path.resolve(currentDir, `${fileName}.assets`)
+    }
+    // Custom path (may contain ${filename} placeholder)
+    return Path.resolve(currentDir, storage.replace(/\${filename}/g, fileName))
   }
 
   _getExtension = (file) => {
@@ -206,16 +206,10 @@ class FileRulesPlugin extends BasePlugin {
       .join("/")
   }
 
-  _generateMarkdown = (relativePath, displayName, isImage) => {
+  _generateMarkdown = (finalPath, displayName, isImage) => {
     const prefix = isImage ? "!" : ""
     const safeName = displayName.replace(/[\[\]()]/g, "\\$&")
-    return `${prefix}[${safeName}](${relativePath})`
-  }
-
-  _timestamp = () => {
-    const now = new Date()
-    const pad = n => String(n).padStart(2, "0")
-    return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`
+    return `${prefix}[${safeName}](${finalPath})`
   }
 }
 

--- a/plugin/global/locales/en.json
+++ b/plugin/global/locales/en.json
@@ -1723,5 +1723,21 @@
     "$tooltip.coord1": "Increments leftwards",
     "$tooltip.exclusive": "Mutually exclusive with 'Custom Callback'",
     "$placeholder.customCallback": "() => window.confirm('Custom action running...')"
+  },
+  "file_rules": {
+    "pluginName": "File Rules",
+    "notify.copySuccess": "File copied to {{folder}}",
+    "notify.copySuccessBatch": "{{count}} files copied to {{folder}}",
+    "notify.copyFailed": "Failed to copy file: {{error}}",
+    "notify.noFile": "No file path available. Please save the document first.",
+    "notify.pathTraversal": "Path traversal attempt blocked. Invalid filename.",
+    "notify.noOriginalPath": "Cannot use original file: file path is not available. Enable copy_to_assets or ensure file has a valid path.",
+    "notify.fileNameCollision": "File name collision after 100 attempts: {{name}}. Please rename the source file.",
+    "$label.COPY_TO_ASSETS": "Copy to Assets Folder",
+    "$label.USE_RELATIVE_PATH": "Use Relative Paths",
+    "$label.ESCAPE_URL": "Escape URL Special Characters",
+    "$label.TARGET_FOLDER": "Custom Target Folder",
+    "$tooltip.defaultTargetFolder": "Leave empty to use ./{filename}.assets/ convention",
+    "$tooltip.escapeUrl": "URL-encode spaces and special characters in file paths"
   }
 }

--- a/plugin/global/locales/en.json
+++ b/plugin/global/locales/en.json
@@ -1724,14 +1724,12 @@
     "$tooltip.exclusive": "Mutually exclusive with 'Custom Callback'",
     "$placeholder.customCallback": "() => window.confirm('Custom action running...')"
   },
-  "file_rules": {
-    "pluginName": "File Rules",
+  "assets_storage": {
+    "pluginName": "Assets Storage",
     "notify.copySuccess": "File copied to {{folder}}",
     "notify.copySuccessBatch": "{{count}} files copied to {{folder}}",
     "notify.copyFailed": "Failed to copy file: {{error}}",
-    "notify.noFile": "No file path available. Please save the document first.",
     "notify.pathTraversal": "Path traversal attempt blocked. Invalid filename.",
-    "notify.fileNameCollision": "File name collision after 100 attempts: {{name}}. Please rename the source file.",
-    "$label.COPY_TO_ASSETS": "Copy Files to Assets Folder"
+    "notify.fileNameCollision": "File name collision after 100 attempts: {{name}}. Please rename the source file."
   }
 }

--- a/plugin/global/locales/en.json
+++ b/plugin/global/locales/en.json
@@ -1731,13 +1731,7 @@
     "notify.copyFailed": "Failed to copy file: {{error}}",
     "notify.noFile": "No file path available. Please save the document first.",
     "notify.pathTraversal": "Path traversal attempt blocked. Invalid filename.",
-    "notify.noOriginalPath": "Cannot use original file: file path is not available. Enable copy_to_assets or ensure file has a valid path.",
     "notify.fileNameCollision": "File name collision after 100 attempts: {{name}}. Please rename the source file.",
-    "$label.COPY_TO_ASSETS": "Copy to Assets Folder",
-    "$label.USE_RELATIVE_PATH": "Use Relative Paths",
-    "$label.ESCAPE_URL": "Escape URL Special Characters",
-    "$label.TARGET_FOLDER": "Custom Target Folder",
-    "$tooltip.defaultTargetFolder": "Leave empty to use ./{filename}.assets/ convention",
-    "$tooltip.escapeUrl": "URL-encode spaces and special characters in file paths"
+    "$label.COPY_TO_ASSETS": "Copy Files to Assets Folder"
   }
 }

--- a/plugin/global/locales/zh-CN.json
+++ b/plugin/global/locales/zh-CN.json
@@ -1723,5 +1723,21 @@
     "$tooltip.coord1": "向左递增",
     "$tooltip.exclusive": "与「自定义回调」互斥",
     "$placeholder.customCallback": "() => window.confirm('Custom Callback')"
+  },
+  "file_rules": {
+    "pluginName": "文件规则",
+    "notify.copySuccess": "文件已复制到 {{folder}}",
+    "notify.copySuccessBatch": "{{count}} 个文件已复制到 {{folder}}",
+    "notify.copyFailed": "复制文件失败: {{error}}",
+    "notify.noFile": "无可用文件路径，请先保存文档。",
+    "notify.pathTraversal": "检测到路径穿越攻击，文件名无效。",
+    "notify.noOriginalPath": "无法使用原始文件：文件路径不可用。请启用 copy_to_assets 或确保文件具有有效路径。",
+    "notify.fileNameCollision": "100 次尝试后仍存在文件名冲突：{{name}}。请重命名源文件。",
+    "$label.COPY_TO_ASSETS": "复制到资源文件夹",
+    "$label.USE_RELATIVE_PATH": "使用相对路径",
+    "$label.ESCAPE_URL": "转义 URL 特殊字符",
+    "$label.TARGET_FOLDER": "自定义目标文件夹",
+    "$tooltip.defaultTargetFolder": "留空则使用 ./{filename}.assets/ 约定",
+    "$tooltip.escapeUrl": "对文件路径中的空格和特殊字符进行 URL 编码"
   }
 }

--- a/plugin/global/locales/zh-CN.json
+++ b/plugin/global/locales/zh-CN.json
@@ -1724,14 +1724,12 @@
     "$tooltip.exclusive": "与「自定义回调」互斥",
     "$placeholder.customCallback": "() => window.confirm('Custom Callback')"
   },
-  "file_rules": {
-    "pluginName": "文件规则",
+  "assets_storage": {
+    "pluginName": "资源存储",
     "notify.copySuccess": "文件已复制到 {{folder}}",
     "notify.copySuccessBatch": "{{count}} 个文件已复制到 {{folder}}",
     "notify.copyFailed": "复制文件失败: {{error}}",
-    "notify.noFile": "无可用文件路径，请先保存文档。",
     "notify.pathTraversal": "检测到路径穿越攻击，文件名无效。",
-    "notify.fileNameCollision": "100 次尝试后仍存在文件名冲突：{{name}}。请重命名源文件。",
-    "$label.COPY_TO_ASSETS": "复制文件到资源文件夹"
+    "notify.fileNameCollision": "100 次尝试后仍存在文件名冲突：{{name}}。请重命名源文件。"
   }
 }

--- a/plugin/global/locales/zh-CN.json
+++ b/plugin/global/locales/zh-CN.json
@@ -1731,13 +1731,7 @@
     "notify.copyFailed": "复制文件失败: {{error}}",
     "notify.noFile": "无可用文件路径，请先保存文档。",
     "notify.pathTraversal": "检测到路径穿越攻击，文件名无效。",
-    "notify.noOriginalPath": "无法使用原始文件：文件路径不可用。请启用 copy_to_assets 或确保文件具有有效路径。",
     "notify.fileNameCollision": "100 次尝试后仍存在文件名冲突：{{name}}。请重命名源文件。",
-    "$label.COPY_TO_ASSETS": "复制到资源文件夹",
-    "$label.USE_RELATIVE_PATH": "使用相对路径",
-    "$label.ESCAPE_URL": "转义 URL 特殊字符",
-    "$label.TARGET_FOLDER": "自定义目标文件夹",
-    "$tooltip.defaultTargetFolder": "留空则使用 ./{filename}.assets/ 约定",
-    "$tooltip.escapeUrl": "对文件路径中的空格和特殊字符进行 URL 编码"
+    "$label.COPY_TO_ASSETS": "复制文件到资源文件夹"
   }
 }

--- a/plugin/global/locales/zh-TW.json
+++ b/plugin/global/locales/zh-TW.json
@@ -1723,5 +1723,21 @@
     "$tooltip.coord1": "向左遞增",
     "$tooltip.exclusive": "與「自訂回呼」互斥",
     "$placeholder.customCallback": "() => window.confirm('Custom Callback')"
+  },
+  "file_rules": {
+    "pluginName": "檔案規則",
+    "notify.copySuccess": "檔案已複製到 {{folder}}",
+    "notify.copySuccessBatch": "{{count}} 個檔案已複製到 {{folder}}",
+    "notify.copyFailed": "複製檔案失敗: {{error}}",
+    "notify.noFile": "無可用檔案路徑，請先儲存文件。",
+    "notify.pathTraversal": "偵測到路徑穿越攻擊，檔名無效。",
+    "notify.noOriginalPath": "無法使用原始檔案：檔案路徑不可用。請啟用 copy_to_assets 或確保檔案具有有效路徑。",
+    "notify.fileNameCollision": "100 次嘗試後仍存在檔名衝突：{{name}}。請重新命名來源檔案。",
+    "$label.COPY_TO_ASSETS": "複製到資源資料夾",
+    "$label.USE_RELATIVE_PATH": "使用相對路徑",
+    "$label.ESCAPE_URL": "逸出 URL 特殊字元",
+    "$label.TARGET_FOLDER": "自訂目標資料夾",
+    "$tooltip.defaultTargetFolder": "留空則使用 ./{filename}.assets/ 慣例",
+    "$tooltip.escapeUrl": "對檔案路徑中的空格和特殊字元進行 URL 編碼"
   }
 }

--- a/plugin/global/locales/zh-TW.json
+++ b/plugin/global/locales/zh-TW.json
@@ -1724,14 +1724,12 @@
     "$tooltip.exclusive": "與「自訂回呼」互斥",
     "$placeholder.customCallback": "() => window.confirm('Custom Callback')"
   },
-  "file_rules": {
-    "pluginName": "檔案規則",
+  "assets_storage": {
+    "pluginName": "資源儲存",
     "notify.copySuccess": "檔案已複製到 {{folder}}",
     "notify.copySuccessBatch": "{{count}} 個檔案已複製到 {{folder}}",
     "notify.copyFailed": "複製檔案失敗: {{error}}",
-    "notify.noFile": "無可用檔案路徑，請先儲存文件。",
     "notify.pathTraversal": "偵測到路徑穿越攻擊，檔名無效。",
-    "notify.fileNameCollision": "100 次嘗試後仍存在檔名衝突：{{name}}。請重新命名來源檔案。",
-    "$label.COPY_TO_ASSETS": "複製檔案到資源資料夾"
+    "notify.fileNameCollision": "100 次嘗試後仍存在檔名衝突：{{name}}。請重新命名來源檔案。"
   }
 }

--- a/plugin/global/locales/zh-TW.json
+++ b/plugin/global/locales/zh-TW.json
@@ -1731,13 +1731,7 @@
     "notify.copyFailed": "複製檔案失敗: {{error}}",
     "notify.noFile": "無可用檔案路徑，請先儲存文件。",
     "notify.pathTraversal": "偵測到路徑穿越攻擊，檔名無效。",
-    "notify.noOriginalPath": "無法使用原始檔案：檔案路徑不可用。請啟用 copy_to_assets 或確保檔案具有有效路徑。",
     "notify.fileNameCollision": "100 次嘗試後仍存在檔名衝突：{{name}}。請重新命名來源檔案。",
-    "$label.COPY_TO_ASSETS": "複製到資源資料夾",
-    "$label.USE_RELATIVE_PATH": "使用相對路徑",
-    "$label.ESCAPE_URL": "逸出 URL 特殊字元",
-    "$label.TARGET_FOLDER": "自訂目標資料夾",
-    "$tooltip.defaultTargetFolder": "留空則使用 ./{filename}.assets/ 慣例",
-    "$tooltip.escapeUrl": "對檔案路徑中的空格和特殊字元進行 URL 編碼"
+    "$label.COPY_TO_ASSETS": "複製檔案到資源資料夾"
   }
 }

--- a/plugin/global/settings/settings.default.toml
+++ b/plugin/global/settings/settings.default.toml
@@ -3272,15 +3272,12 @@ ENABLE = false
 NAME = ""
 
 # =========== [ File Processing Rules ] ===========
-# Copy the pasted/dropped file to the target folder
+# Copy the pasted/dropped non-image file to the target folder.
+# Relative path, URL escaping, and target folder are read from Typora's preferences:
+#   - Use Relative Path  → File.option.useRelativePathForImg
+#   - Escape URL         → File.option.autoEscapeImageURL
+#   - Target Folder      → File.editor.imgEdit.getTargetImageStorageFolder()
 COPY_TO_ASSETS = true
-# Convert the inserted path to a relative path
-USE_RELATIVE_PATH = true
-# URL-encode special characters in the path
-ESCAPE_URL = true
-# Custom destination folder (relative to current markdown file's directory).
-# Empty string means use ./${filename}.assets/ convention.
-TARGET_FOLDER = ""
 
 
 [test]

--- a/plugin/global/settings/settings.default.toml
+++ b/plugin/global/settings/settings.default.toml
@@ -2139,7 +2139,7 @@ LIST = [
   "md_padding",
   "text_stylize",
   "markdownlint",
-  "file_rules",
+  "assets_storage",
 ]
 [[right_click_menu.MENUS]]
 NAME = "__COMPONENT_PLUGINS__"
@@ -3266,18 +3266,16 @@ DEFAULT_ICON = "\\f075"
 TEMPLATE = "> [!NOTE]\n> Support Type: TIP、BUG、INFO、NOTE、QUOTE、EXAMPLE、CAUTION、FAILURE、WARNING、SUCCESS、QUESTION、ABSTRACT、IMPORTANT"
 
 
-[file_rules]
+[assets_storage]
 # =========== [ Basic ] ===========
 ENABLE = false
 NAME = ""
 
-# =========== [ File Processing Rules ] ===========
-# Copy the pasted/dropped non-image file to the target folder.
-# Relative path, URL escaping, and target folder are read from Typora's preferences:
+# Copy pasted/dropped files (images and non-images) to the target folder.
+# Target folder, relative path, and URL escaping are read from Typora's preferences:
+#   - Target Folder      → File.option.defaultImageStorage
 #   - Use Relative Path  → File.option.useRelativePathForImg
 #   - Escape URL         → File.option.autoEscapeImageURL
-#   - Target Folder      → File.editor.imgEdit.getTargetImageStorageFolder()
-COPY_TO_ASSETS = true
 
 
 [test]

--- a/plugin/global/settings/settings.default.toml
+++ b/plugin/global/settings/settings.default.toml
@@ -2139,6 +2139,7 @@ LIST = [
   "md_padding",
   "text_stylize",
   "markdownlint",
+  "file_rules",
 ]
 [[right_click_menu.MENUS]]
 NAME = "__COMPONENT_PLUGINS__"
@@ -3263,6 +3264,23 @@ DEFAULT_ICON = "\\f075"
 # =========== [ Template ] ===========
 # Template: Default sample padding content when inserting
 TEMPLATE = "> [!NOTE]\n> Support Type: TIP、BUG、INFO、NOTE、QUOTE、EXAMPLE、CAUTION、FAILURE、WARNING、SUCCESS、QUESTION、ABSTRACT、IMPORTANT"
+
+
+[file_rules]
+# =========== [ Basic ] ===========
+ENABLE = false
+NAME = ""
+
+# =========== [ File Processing Rules ] ===========
+# Copy the pasted/dropped file to the target folder
+COPY_TO_ASSETS = true
+# Convert the inserted path to a relative path
+USE_RELATIVE_PATH = true
+# URL-encode special characters in the path
+ESCAPE_URL = true
+# Custom destination folder (relative to current markdown file's directory).
+# Empty string means use ./${filename}.assets/ convention.
+TARGET_FOLDER = ""
 
 
 [test]

--- a/plugin/preferences/rules.js
+++ b/plugin/preferences/rules.js
@@ -171,6 +171,7 @@ module.exports = {
   image_viewer: {
     THUMBNAIL_HEIGHT: required,
   },
+
   markdownlint: {
     BUTTON_WIDTH: required,
     BUTTON_HEIGHT: required,

--- a/plugin/preferences/schemas.js
+++ b/plugin/preferences/schemas.js
@@ -1500,11 +1500,8 @@ const schema_action_buttons = () => [
   FRAG.SettingHandler(),
 ]
 
-const schema_file_rules = () => [
+const schema_assets_storage = () => [
   FRAG.Base(),
-  Group(
-    Switch("COPY_TO_ASSETS"),
-  ),
   FRAG.SettingHandler(),
 ]
 
@@ -1571,7 +1568,7 @@ const RAW_SCHEMA_FNS = {
   plantUML: schema_plantUML,
   marp: schema_marp,
   callouts: schema_callouts,
-  file_rules: schema_file_rules,
+  assets_storage: schema_assets_storage,
 }
 
 const mapTree = (schemas, visitBox = box => box, visitField = field => field, prefix = "") => schemas.map(box => {

--- a/plugin/preferences/schemas.js
+++ b/plugin/preferences/schemas.js
@@ -1500,6 +1500,17 @@ const schema_action_buttons = () => [
   FRAG.SettingHandler(),
 ]
 
+const schema_file_rules = () => [
+  FRAG.Base(),
+  Group(
+    Switch("COPY_TO_ASSETS"),
+    Switch("USE_RELATIVE_PATH"),
+    Switch("ESCAPE_URL").Tooltip("escapeUrl"),
+    Text("TARGET_FOLDER").Placeholder("defaultIfEmpty").Tooltip("defaultTargetFolder"),
+  ),
+  FRAG.SettingHandler(),
+]
+
 const RAW_SCHEMA_FNS = {
   global: schema_global,
   window_tab: schema_window_tab,
@@ -1563,6 +1574,7 @@ const RAW_SCHEMA_FNS = {
   plantUML: schema_plantUML,
   marp: schema_marp,
   callouts: schema_callouts,
+  file_rules: schema_file_rules,
 }
 
 const mapTree = (schemas, visitBox = box => box, visitField = field => field, prefix = "") => schemas.map(box => {

--- a/plugin/preferences/schemas.js
+++ b/plugin/preferences/schemas.js
@@ -1504,9 +1504,6 @@ const schema_file_rules = () => [
   FRAG.Base(),
   Group(
     Switch("COPY_TO_ASSETS"),
-    Switch("USE_RELATIVE_PATH"),
-    Switch("ESCAPE_URL").Tooltip("escapeUrl"),
-    Text("TARGET_FOLDER").Placeholder("defaultIfEmpty").Tooltip("defaultTargetFolder"),
   ),
   FRAG.SettingHandler(),
 ]


### PR DESCRIPTION
Add a new plugin that intercepts paste and drop events to automatically copy files to .assets directory and insert Markdown syntax based on configurable extension rules.

Features:
- Support for copy_to_assets, use_relative_path, escape_url options
- Path traversal protection and filename collision handling
- i18n support (en, zh-CN, zh-TW)
- Preferences UI schema for rule configuration
- Aggregated notifications for multi-file operations