### PR TITLE
fix(window_tab): rerenderTabBar no longer opens a second window

### DIFF
--- a/develop/test/window_tab.test.js
+++ b/develop/test/window_tab.test.js
@@ -61,6 +61,37 @@ describe("TabManager Test Suite", () => {
     })
   })
 
+  describe("1b. refresh() - Redraw Without Reopening", () => {
+    it("should render the active path without opening any file", () => {
+      manager.reset([{ path: "/a.md" }, { path: "/b.md" }])
+      manager._activeIdx = 1
+      context.utils.openFile.mock.resetCalls()
+
+      manager.refresh()
+
+      assert.strictEqual(context.onRender.mock.callCount(), 1)
+      assert.strictEqual(context.onRender.mock.calls[0].arguments[0], "/b.md")
+      assert.strictEqual(context.utils.openFile.mock.callCount(), 0)
+    })
+
+    it("should recompute labels so a config change takes effect", () => {
+      context.config.SHOW_DIR_ON_DUPLICATE = false
+      manager.reset([{ path: "/x/a.md" }, { path: "/y/a.md" }])
+      assert.deepStrictEqual(manager.tabs.map(t => t.showName), ["a.md", "a.md"])
+
+      context.config.SHOW_DIR_ON_DUPLICATE = true
+      manager.refresh()
+
+      assert.deepStrictEqual(manager.tabs.map(t => t.showName), ["x/a.md", "y/a.md"])
+    })
+
+    it("should not throw when there is no tab left", () => {
+      manager.reset([])
+      manager.refresh()
+      assert.strictEqual(context.onRender.mock.calls[0].arguments[0], undefined)
+    })
+  })
+
   describe("2. open() - Tab Insertion and Trimming", () => {
     it("should modify current tab path when local open is true", () => {
       manager.reset([{ path: "/original.md" }])

--- a/plugin/window_tab.js
+++ b/plugin/window_tab.js
@@ -99,6 +99,16 @@ class TabManager {
     this.utils.openFile(this.current?.path, true)
   }
 
+  /**
+   * Redraw the tab bar for the current state, without touching the document.
+   * Labels are recomputed because they depend on TRIM_FILE_EXT and
+   * SHOW_DIR_ON_DUPLICATE, which the caller may have just changed.
+   */
+  refresh() {
+    this._formatShowNames()
+    this.hooks.onRender(this.current?.path)
+  }
+
   switchByPath(path) {
     const idx = this._findIndexByPath(path)
     if (idx !== -1) this.switch(idx)
@@ -918,7 +928,7 @@ class WindowTabPlugin extends BasePlugin {
 
   rerenderTabBar = () => {
     this.entities.tabWrapper.replaceChildren()
-    this.utils.openFile(this.tab.current?.path)
+    this.tab.refresh()
   }
 
   copyPath = idx => navigator.clipboard.writeText(this.tab.getPathByIdx(idx) || "")


### PR DESCRIPTION
rerenderTabBar() ended with utils.openFile(path) without force, which falls back to openFileInNewWindow whenever no folder is mounted or the file sits outside it. Toggling a tab bar option on a single file opened without a folder therefore spawns a second window with the same document.

The call cannot simply be dropped: it is also what refreshed the tab labels, through fileOpened -> TabManager.open() -> _formatShowNames(). TabManager gains a refresh() that does that part directly, and rerenderTabBar uses it.

Adds three tests: refresh renders the active path, opens no file, and recomputes labels after a config change.